### PR TITLE
Add Custom IP/Port, Support Xbox360/X1S/XSS Vibration, Auto Disconnect  for timeout 15s 

### DIFF
--- a/NetInput.Capture/NetInput.Capture.cpp
+++ b/NetInput.Capture/NetInput.Capture.cpp
@@ -13,9 +13,55 @@
 #include <stdint.h>
 #include <fstream>
 
+
+#define PAD_OUT_SIZE 5
+#define PAD_ONLINE 0x00
+#define PAD_VIBRA 0x01
+
 SOCKET sock;
 struct sockaddr_in addr;
 XINPUT_STATE lastSentInputStates[XUSER_MAX_COUNT];
+
+void CheckControllerMessage()
+{ 
+	while (true)
+	{
+		if (GetKeyState(VK_ESCAPE) & 0x8000)
+			break;
+		
+		char packet[PAD_OUT_SIZE];
+		int addr_size = sizeof(addr);
+		int bytesReceived = recvfrom(sock, (char*)&packet, sizeof(packet), 0, (struct sockaddr*)&addr, &addr_size);		
+		if (bytesReceived == PAD_OUT_SIZE){	
+			uint8_t i = (uint8_t)packet[1];
+			if ((i >= 0) && (i < XUSER_MAX_COUNT)) {
+				if (packet[0] == PAD_ONLINE) {
+					XINPUT_VIBRATION Vibration;
+					
+					uint8_t pindex = (uint8_t)packet[4];
+					Vibration.wLeftMotorSpeed = 0;
+					Vibration.wRightMotorSpeed = -1;
+					XInputSetState(i, &Vibration);
+
+					printf("Get Local controller %u as Online controller %u.\n", i,pindex);
+					std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+					Vibration.wLeftMotorSpeed = 0;
+					Vibration.wRightMotorSpeed = 0;
+					XInputSetState(i, &Vibration);
+
+				}
+				else if (packet[0] == PAD_VIBRA) {
+					XINPUT_VIBRATION Vibration;
+					Vibration.wLeftMotorSpeed = packet[2] << 8;
+					Vibration.wRightMotorSpeed = packet[3] << 8;
+					XInputSetState(i, &Vibration);
+				}
+			}
+		}
+	}
+}
+
 
 void SendResetControllers()
 {
@@ -27,7 +73,7 @@ void SendResetControllers()
 void PollControllers() 
 {
 	XINPUT_STATE state;
-	for (uint32_t i = 0u; i < XUSER_MAX_COUNT; i++)
+	for (uint8_t i = 0u; i < XUSER_MAX_COUNT; i++)
 	{
 		memset(&state, 0, sizeof(XINPUT_STATE));
 		if (XInputGetState(i, &state) != ERROR_SUCCESS)
@@ -46,23 +92,19 @@ void PollControllers()
 	}
 }
 
-int main()
+int main(int argc, char* argv[])
 {
 	std::string ip;
-
-	std::ifstream input_file("target.txt");
-	if (input_file.is_open())
-	{
-		printf("Reading ip from target.txt.\n");
-		ip = std::string((std::istreambuf_iterator<char>(input_file)), std::istreambuf_iterator<char>());
-
-		if (inet_pton(AF_INET, ip.c_str(), &(addr.sin_addr)) != 1)
-		{
-			std::cout << ip << " is not a valid ip, please correct target.txt\n";
-			return -1;
-		}
+	int port = 4313;
+	
+	if (argc > 1) {
+		ip = argv[1];
 	}
 
+	if (argc > 2) {
+		sscanf_s(argv[2], "%d", &port);
+	}
+	
 	if (ip.empty())
 	{
 		while (true)
@@ -77,7 +119,13 @@ int main()
 		}
 	}
 
-	printf("Target is %s.\n", ip.c_str());
+	if (inet_pton(AF_INET, ip.c_str(), &(addr.sin_addr)) != 1)
+	{
+		std::cout << ip << " is not a valid ip, please try again ! \n";
+		return -1;
+	}
+
+	printf("Target is %s:%d.\n", ip.c_str(),port);
 
 	CoInitialize(NULL);
 
@@ -99,23 +147,24 @@ int main()
 	}
 
 	addr.sin_family = AF_INET;
-	addr.sin_port = htons(4313);
+	addr.sin_port = htons(port);
 
 	printf("Sending reset...\n");
 	SendResetControllers();
 	printf("Done.\n");
-
 	printf("Waiting for gamepad input, press ESC to exit...\n");
+	
+	std::thread message(CheckControllerMessage); // new thread for vibra notify
+
 	memset(lastSentInputStates, 0, sizeof(lastSentInputStates));
 	while (true)
 	{
 		if (GetKeyState(VK_ESCAPE) & 0x8000)
 			break;
-
 		PollControllers();
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 	}
-
+	printf("Wait For Closing...\n");
 	SendResetControllers();
 	closesocket(sock);
 	WSACleanup();

--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ The Player will see if a gamepad with that index is connected. If not, a new vir
 # 1.13 By QeeAI
 
 2023.2.2 
-
 1. Server (Custom Port)      :  netinput.paly.exe 0-65536 (Default 4313)
 2. Client (Custom IPV4/Port) :  netinput.capture.exe 192.168.1.31 (for example) 0-65536 (Default 4313) ,  "target.txt" never use .
 3. Support Xbox360/X1S/XSS Vibration 
-4. GamePads Arrays depended By Client IP ，Port, and Local Xbox controller Index Id 。
-5. Add UDP Client HeartBreak every 5s, TimeOut 15s to break.
+4. GamePads depended By Client IP ，Port, and Local Xbox controller Index Id 。
+5. Added UDP Client HeartBreak every 5s, TimeOut 15s to break.
 
 2023年2月2日
 1. 服务端 (自定义端口)    :  netinput.paly.exe 4313（0-65536）
@@ -57,3 +56,10 @@ The Player will see if a gamepad with that index is connected. If not, a new vir
 
 
 
+# 1.14 By QeeAI
+
+2023.2.4 
+GamePads depended By Client Mac Address and Xbox controller Index Id now.
+
+2023年2月4日
+服务端的手柄分组现在按客户端MAC地址和XBOX手柄序号共同决定。

--- a/README.md
+++ b/README.md
@@ -38,20 +38,22 @@ The Player will see if a gamepad with that index is connected. If not, a new vir
 - ViGEmBus https://github.com/ViGEm/ViGEmBus/releases
 
 # Thank  usertoroot 
-# 1.12 By QeeAI
+# 1.13 By QeeAI
 
-2023.1.31 
+2023.2.2 
 
-1. Server :  netinput.paly.exe 0-65536 (Default 4313)
-2. Client :  netinput.capture.exe 192.168.1.31 (for example) 0-65536 (Default 4313) ,  "target.txt" never use .
-3. Support Xbox360/One/XSS Vibration 
-4. Pads re-Arrays depended By ClientIP and Local XboxId。
+1. Server (Custom Port)      :  netinput.paly.exe 0-65536 (Default 4313)
+2. Client (Custom IPV4/Port) :  netinput.capture.exe 192.168.1.31 (for example) 0-65536 (Default 4313) ,  "target.txt" never use .
+3. Support Xbox360/X1S/XSS Vibration 
+4. GamePads Arrays depended By Client IP ，Port, and Local Xbox controller Index Id 。
+5. Add UDP Client HeartBreak every 5s, TimeOut 15s to break.
 
-2023年1月31日
-1. 服务端 增加自定义端口 netinput.paly.exe 4313（0-65536）
-2.  客户端  增加自定义IP和端口，取消target.txt的参数文件，  netinput.capture.exe 192.168.1.31（自定义）  4313（0-65536）
-3. 现在可以完美支持XBOX手柄震动。
-4. 服务端的手柄分组ID现在按IP和本地XBOXID共同决定。
+2023年2月2日
+1. 服务端 (自定义端口)    :  netinput.paly.exe 4313（0-65536）
+2. 客户端 (自定义IP和端口) :  netinput.capture.exe 192.168.1.31（自定义）  4313（0-65536） ， target.txt 不再使用。
+3. 现在可以完美支持Xbox360/X1S/XSS手柄震动。
+4. 服务端的手柄分组现在按IP,端口和本地XBOX手柄序号共同决定。
+5. 增加客户端手柄的心跳连接每5秒1次，超时15秒自动断开。
 
 
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,22 @@ The Player will see if a gamepad with that index is connected. If not, a new vir
 ## Requirements
 
 - ViGEmBus https://github.com/ViGEm/ViGEmBus/releases
+
+# Thank  usertoroot 
+# 1.12 By QeeAI
+
+2023.1.31 
+
+1. Server :  netinput.paly.exe 0-65536 (Default 4313)
+2. Client :  netinput.capture.exe 192.168.1.31 (for example) 0-65536 (Default 4313) ,  "target.txt" never use .
+3. Support Xbox360/One/XSS Vibration 
+4. Pads re-Arrays depended By ClientIP and Local XboxId。
+
+2023年1月31日
+1. 服务端 增加自定义端口 netinput.paly.exe 4313（0-65536）
+2.  客户端  增加自定义IP和端口，取消target.txt的参数文件，  netinput.capture.exe 192.168.1.31（自定义）  4313（0-65536）
+3. 现在可以完美支持XBOX手柄震动。
+4. 服务端的手柄分组ID现在按IP和本地XBOXID共同决定。
+
+
+

--- a/README.md
+++ b/README.md
@@ -55,11 +55,17 @@ The Player will see if a gamepad with that index is connected. If not, a new vir
 5. 增加客户端手柄的心跳连接每5秒1次，超时15秒自动断开。
 
 
-
 # 1.14 By QeeAI
-
-2023.2.4 
+2023.2.4
 GamePads depended By Client Mac Address and Xbox controller Index Id now.
 
 2023年2月4日
 服务端的手柄分组现在按客户端MAC地址和XBOX手柄序号共同决定。
+
+
+# 1.15 By QeeAI
+2023.2.5
+Added check valid for client mac address.
+
+2023年2月5日
+增加客户端MAC地址的有效性校验。


### PR DESCRIPTION
Server (Custom Port) : netinput.paly.exe 0-65536 (Default 4313)
Client (Custom IPV4/Port) : netinput.capture.exe 192.168.1.31 (for example) 0-65536 (Default 4313) , "target.txt" never use .
Support Xbox360/X1S/XSS Vibration
GamePads Arrays depended By Client IP ，Port, and Local Xbox controller Index Id 。
Add UDP Client HeartBreak every 5s, TimeOut 15s to break.